### PR TITLE
Django fieldsignals installable with pip

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include LICENSE
+include README.rst
+recursive-include fieldsignals/static *
+recursive-include fieldsignals/templates *

--- a/README.rst
+++ b/README.rst
@@ -42,3 +42,20 @@ new values of your fields::
     
     pre_save_changed.connect(print_all_field_changes, sender=Poll)
 
+Installation
+-----------
+
+1. This library is on PyPI so you can install it with::
+
+    pip install django-fieldsignals
+
+or from github::
+
+    pip install git+https://github.com/craigds/django-fieldsignals.git#egg=django-fieldsignals
+
+2. Add "polls" to your INSTALLED_APPS setting like this::
+
+    INSTALLED_APPS = (
+        ...
+        'fieldsignals',
+    )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,32 @@
+import os
+from setuptools import setup
+
+README = open(os.path.join(os.path.dirname(__file__), 'README.rst')).read()
+
+# allow setup.py to be run from any path
+os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
+
+setup(
+    name='django-fieldsignals',
+    version='0.1',
+    packages=['fieldsignals'],
+    include_package_data=True,
+    description='Django fieldsignals simply makes it easy to tell when the fields on your model have changed.',
+    long_description=README,
+    url='https://github.com/PetrDlouhy/django-fieldsignals',
+    author='Craig de Stigter',
+    author_email='craig.ds@gmail.com',
+    classifiers=[
+        'Environment :: Web Environment',
+        'Framework :: Django',
+        'Intended Audience :: Developers',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        # Replace these appropriately if you are stuck on Python 2.
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.2',
+        'Programming Language :: Python :: 3.3',
+        'Topic :: Internet :: WWW/HTTP',
+        'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
+    ],
+)


### PR DESCRIPTION
Hello, I made few additions, that make possible to install django-fieldsignals with pip. Please check, if I filled correctly your information to setup.py.

I filled the installation instructions as if the package was already on PyPI, but I didn't want to steal your application name there. So please register your application on https://pypi.python.org/pypi and upload it there.