### PR TITLE
fix AppConfig ready condition

### DIFF
--- a/fieldsignals/signals.py
+++ b/fieldsignals/signals.py
@@ -21,7 +21,7 @@ class ChangedSignal(Signal):
             foo.connect(func, sender=MyModel, fields=['myfield1', 'myfield2'])
         """
 
-        if not apps.ready:
+        if not apps.models_ready:
             # We require access to Model._meta.get_fields(), which isn't available yet.
             # (This error would be raised below anyway, but we want to add a more meaningful message)
             raise AppRegistryNotReady(

--- a/fieldsignals/tests/test_signals.py
+++ b/fieldsignals/tests/test_signals.py
@@ -85,7 +85,7 @@ class FakeModelWithOneToOne(object):
 
 class TestGeneral(TestCase):
     def setUp(self):
-        apps.ready = True
+        apps.models_ready = True
 
     def test_m2m_fields_error(self):
         with must_be_called(False) as func:
@@ -102,7 +102,7 @@ class TestGeneral(TestCase):
             post_save_changed.connect(func, sender=FakeModelWithOneToOne)
 
     def test_app_cache_not_ready(self):
-        apps.ready = False
+        apps.models_ready = False
         with self.assertRaisesRegexp(AppRegistryNotReady, r"django-fieldsignals signals.*"):
             post_save_changed.connect(func, sender=FakeModel)
 
@@ -110,7 +110,7 @@ class TestGeneral(TestCase):
 
 class TestPostSave(TestCase):
     def setUp(self):
-        apps.ready = True
+        apps.models_ready = True
 
     def test_post_save_unchanged(self):
         with must_be_called(False) as func:
@@ -154,7 +154,7 @@ class TestPostSave(TestCase):
 
 class TestPreSave(TestCase):
     def setUp(self):
-        apps.ready = True
+        apps.models_ready = True
 
     def test_pre_save_unchanged(self):
         with must_be_called(False) as func:


### PR DESCRIPTION
Fix of `apps.ready` condition in https://github.com/craigds/django-fieldsignals/commit/8607a699b5267a8f5e6caccb832324f6aecf00a2#diff-a962eb2c68e7bee41e1dadef0d1bb42fR24
