### PR TITLE
django.utils.six is removed in latest Django

### DIFF
--- a/fieldsignals/signals.py
+++ b/fieldsignals/signals.py
@@ -5,14 +5,13 @@ from django.core.exceptions import AppRegistryNotReady
 from django.db.models.fields.related import ForeignObjectRel
 from django.db.models import signals as _signals
 from django.dispatch import Signal
-from django.utils import six
 
 
 __all__ = ('pre_save_changed', 'post_save_changed')
 
 
 IMMUTABLE_TYPES_WHITELIST = tuple(
-    [tuple, frozenset, float] + list(six.string_types + six.integer_types)
+    [tuple, frozenset, float, str, int]
 )
 
 


### PR DESCRIPTION
django.utils.six is removed as per https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis, since Django is dropping support for Python2